### PR TITLE
修正Logstash的模版配置文件

### DIFF
--- a/ELK/Template/logstash/conf.d/debug.conf
+++ b/ELK/Template/logstash/conf.d/debug.conf
@@ -52,12 +52,12 @@ filter {
             ]
         }
     }
-    ruby {
-        code => "event.set('timestamp', event.get('@timestamp').time.localtime + 8*60*60)"
-    }
-    ruby {
-        code => "event.set('@timestamp', event.get('timestamp'))"
-    }
+    # ruby {
+    #     code => "event.set('timestamp', event.get('@timestamp').time.localtime + 8*60*60)"
+    # }
+    # ruby {
+    #     code => "event.set('@timestamp', event.get('timestamp'))"
+    # }
     mutate {
         remove_field => [
             "tags",

--- a/ELK/Template/logstash/conf.d/main.conf
+++ b/ELK/Template/logstash/conf.d/main.conf
@@ -52,14 +52,13 @@ filter {
                 "yyyy-MM-dd HH:mm:ss.SSS"
             ]
         }
-    } else {
-        ruby {
-            code => "event.set('timestamp', event.get('@timestamp').time.localtime + 8*60*60)"
-        }
     }
-    ruby {
-        code => "event.set('@timestamp', event.get('timestamp'))"
-    }
+    # ruby {
+    #     code => "event.set('timestamp', event.get('@timestamp').time.localtime + 8*60*60)"
+    # }
+    # ruby {
+    #     code => "event.set('@timestamp', event.get('timestamp'))"
+    # }
     mutate {
         remove_field => [
             "tags",


### PR DESCRIPTION
取消下述配置：
```
    ...
    ruby {
        code => "event.set('@timestamp', event.get('timestamp'))"
    }
    ...
```

该配置语句是网上流行的一种传统做法，用于替换`@timestamp`的时间戳，但实际没有效果，且会因`timestamp`是字符串类型，与`@timestamp`数据类型不同，导致下述大量报错：

```
2023-08-24 13:21:53.120 ERROR [logstash.filters.ruby] Ruby exception occurred: wrong argument type String (expected LogStash::Timestamp) {:class=>"TypeError", :backtrace=>["org/logstash/ext/JrubyEventExtLibrary.java:95:in `set'", "(ruby filter code):2:in `block in filter_method'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-filter-ruby-3.1.7/lib/logstash/filters/ruby.rb:93:in `inline_script'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-filter-ruby-3.1.7/lib/logstash/filters/ruby.rb:86:in `filter'", "/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:143:in `do_filter'", "/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:162:in `block in multi_filter'", "org/jruby/RubyArray.java:1792:in `each'", "/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:159:in `multi_filter'", "org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java:115:in `multi_filter'", "(eval):172:in `block in filter_func'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:358:in `filter_batch'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:337:in `worker_loop'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:304:in `block in start_workers'"]}
```