### PR TITLE
增加 MAX_INFLIGHT_WARN_THRESHOLD 宏变量引起的 WARN 告警的说明

### DIFF
--- a/ELK/03 Logstash I
+++ b/ELK/03 Logstash I
@@ -127,15 +127,19 @@ Logstash 软件的 YAML 配置文件
 # /etc/logstash/logstash.yml 服务配置文件登记的参数为软件默认参数, 默认参数的优先级较低, 允许被其余配置文件参数覆盖
 # node.name: demo                                Logstash 节点使用的名称标识
 # pipeline.java_execution: false                 Logstash 节点关闭 Java 内核引擎
-# pipeline.workers: 1                            Logstash 节点启动单个线程管理数据管道 (参数值建议与 CPU 核心数量保持一致)
-# pipeline.batch.size: 125                       Logstash 节点启动单个线程最多同时处理 125 个数据事件
-# pipeline.batch.delay: 50                       Logstash 节点在分发数据事件时, 分发动作每次间隔 50 毫秒
+# pipeline.workers: 1                            Logstash 节点启动单个线程消费上游数据 (参数值建议与 CPU 核心数量保持一致)
+# pipeline.batch.size: 125                       Logstash 节点的每个消费线程每批次处理 125 个数据事件
+# pipeline.batch.delay: 50                       Logstash 节点的每个消费线程间隔 50 毫秒触发一次消费动作
 # path.data: /var/lib/logstash                   Logstash 节点使用的数据文件存储目录
 # path.logs: /var/log/logstash                   Logstash 节点使用的日志文件存储目录
 # http.host: 127.0.0.1                           Logstash 节点使用的 HTTP 服务监听范围
 # http.port: 9600                                Logstash 节点使用的 HTTP 服务监听端口
 # log.level: info                                Logstash 节点仅输出 INFO 级别以上的软件运行日志
 
+阅读上述内容时, 还请注意:
+
+    •  参数 pipeline.workers * pipeline.batch.size > 10000 (MAX_INFLIGHT_WARN_THRESHOLD) 时会触发 WARN 级别的警告日志
+    •  消费线程处理大规模数据事件时, 需要设置更大的 JVM 内存容量
 
 """"""""" 演示 /etc/logstash/logstash.yml 文件的基本配置
 [root ~]# cat /etc/logstash/logstash.yml
@@ -156,9 +160,9 @@ log.level: info
 # /etc/logstash/pipelines.yml 管道参数文件登记的参数为软件管道参数, 其优先级高于服务配置文件内登记的管道参数
 # pipeline.id: main
 # pipeline.java_execution: false                 Logstash 节点关闭 Java 内核引擎
-# pipeline.workers: 1                            Logstash 节点启动单个线程管理数据管道 (参数值建议与 CPU 核心数量保持一致)
-# pipeline.batch.size: 125                       Logstash 节点启动单个线程最多同时处理 125 个数据事件
-# pipeline.batch.delay: 50                       Logstash 节点在分发数据事件时, 分发动作每次间隔 50 毫秒
+# pipeline.workers: 1                            Logstash 节点启动单个线程消费上游数据 (参数值建议与 CPU 核心数量保持一致)
+# pipeline.batch.size: 125                       Logstash 节点的每个消费线程每批次处理 125 个数据事件
+# pipeline.batch.delay: 50                       Logstash 节点的每个消费线程间隔 50 毫秒触发一次消费动作
 # path.config: /etc/logstash/conf.d/main.conf    Logstash 节点加载 /etc/logstash/conf.d/main.conf 作为管道配置文件
 
 """"""""" 演示 /etc/logstash/pipelines.yml 文件的基本配置


### PR DESCRIPTION
增加 MAX_INFLIGHT_WARN_THRESHOLD 宏变量引起的 WARN 告警的说明
官方源文件参见![这里](https://github.com/elastic/logstash/blob/50b43ebbaf35a042b9d1848118dcffde264dfbc9/logstash-core/lib/logstash/java_pipeline.rb#L227)
