### PR TITLE
补充数据保留参数到 Kafka 组件的示例配置文件内

### DIFF
--- a/Kafka/Template/configure/kraft/server.properties
+++ b/Kafka/Template/configure/kraft/server.properties
@@ -90,3 +90,7 @@ offsets.topic.num.partitions=3
 offsets.topic.replication.factor=3
 # 按批次读取消息时, 每个批次的最大消息体积为 100MiB
 fetch.max.bytes=104857600
+# 节点寄存 10 GB 容量大小的数据
+log.retention.bytes=10485760000
+# 节点寄存的数据保留 168 小时 (7 自然天) 的生命周期
+log.retention.hours=168

--- a/Kafka/Template/configure/server.properties
+++ b/Kafka/Template/configure/server.properties
@@ -87,3 +87,7 @@ offsets.topic.num.partitions=3
 offsets.topic.replication.factor=3
 # 按批次读取消息时, 每个批次的最大消息体积为 100MiB
 fetch.max.bytes=104857600
+# 节点寄存 10 GB 容量大小的数据
+log.retention.bytes=10485760000
+# 节点寄存的数据保留 168 小时 (7 自然天) 的生命周期
+log.retention.hours=168


### PR DESCRIPTION
生产环境的 Kafka 集群务必开启 log.retention.bytes/ log.retention.hours, 有效规避磁盘资源被生产者写爆