### PR TITLE
修正 Logstash.filter.grok.match 配置, 在其中使用 ^ 正则符号, 进一步提高日志命中的准确性

### DIFF
--- a/ELK/Template/logstash/conf.d/debug.conf
+++ b/ELK/Template/logstash/conf.d/debug.conf
@@ -38,9 +38,14 @@ filter {
     grok {
         match => {
             "message" => [
-                "(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}\.\d{3}) %{LOGLEVEL:level} \[%{DATA:feature}\] (?<body>.*$)",
-                "(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}\.\d{3}) (?<body>.*$)",
-                "(?<body>.*$)"
+                # 标准日志格式: 2023-12-12 22:22:22.222 INFO [main] xxxxxxxxxxxxxxxxx
+                "^(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}\.\d{3}) %{LOGLEVEL:level} \[%{DATA:feature}\] (?<body>.*$)",
+                # 标准日志格式: 2023-12-12 22:22:22.222 INFO xxxxxxxxxxxxxxxxx
+                "^(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}*%{HOUR}:%{MINUTE}:%{SECOND}\.\d{3})%{SPACE}*%{LOGLEVEL:level}%{SPACE}*(?<body>.*$)",
+                # 标准日志格式: 2023-12-12 22:22:22.222 xxxxxxxxxxxxxxxxx
+                "^(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}*%{HOUR}:%{MINUTE}:%{SECOND}\.\d{3})%{SPACE}*(?<body>.*$)",
+                # 泛解析日志格式
+                "^(?<body>.*$)"
             ]
         }
     }

--- a/ELK/Template/logstash/conf.d/main.conf
+++ b/ELK/Template/logstash/conf.d/main.conf
@@ -40,13 +40,13 @@ filter {
             match => {
                 "message" => [
                     # 标准日志格式: 2023-12-12 22:22:22.222 INFO [main] xxxxxxxxxxxxxxxxx
-                    "(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}*%{HOUR}:%{MINUTE}:%{SECOND}\.\d{3})%{SPACE}*%{LOGLEVEL:level}%{SPACE}*\[%{DATA:feature}\]%{SPACE}*(?<body>.*$)",
+                    "^(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}*%{HOUR}:%{MINUTE}:%{SECOND}\.\d{3})%{SPACE}*%{LOGLEVEL:level}%{SPACE}*\[%{DATA:feature}\]%{SPACE}*(?<body>.*$)",
                     # 标准日志格式: 2023-12-12 22:22:22.222 INFO xxxxxxxxxxxxxxxxx
-                    "(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}*%{HOUR}:%{MINUTE}:%{SECOND}\.\d{3})%{SPACE}*%{LOGLEVEL:level}%{SPACE}*(?<body>.*$)",
+                    "^(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}*%{HOUR}:%{MINUTE}:%{SECOND}\.\d{3})%{SPACE}*%{LOGLEVEL:level}%{SPACE}*(?<body>.*$)",
                     # 标准日志格式: 2023-12-12 22:22:22.222 xxxxxxxxxxxxxxxxx
-                    "(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}*%{HOUR}:%{MINUTE}:%{SECOND}\.\d{3})%{SPACE}*(?<body>.*$)",
+                    "^(?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}*%{HOUR}:%{MINUTE}:%{SECOND}\.\d{3})%{SPACE}*(?<body>.*$)",
                     # 泛解析日志格式
-                    "(?<body>.*$)"
+                    "^(?<body>.*$)"
                 ]
             }
         }


### PR DESCRIPTION
修正 `Logstash.filter.grok.match` 配置, 在其中使用 `^` 正则符号, 进一步提高日志命中的准确性